### PR TITLE
Update installation instructions

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,6 +4,7 @@ Installation
 
 At the command line::
 
+    $ pip3 install wheel
     $ pip3 install sgframework
 
 This will also install the dependencies ``paho-mqtt`` and ``can4python``.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -18,7 +18,7 @@ Run the canadapter::
 
 To download the example files and test files, you need to use::
  
-    $ git clone https://github.com/caran/sgframework.git
+    $ git clone https://github.com/caran/SecureGateway.git
 
 In order to run tests, you might need to enable the virtual CAN bus. On Debian::
 


### PR DESCRIPTION
The URL to the GitHub repo was outdated. Also installing `sgframework` on a fresh installation of Ubuntu 20.04 results in the error below. This can be fixed by installing `wheel` before installing `sgframework`.

```
Building wheels for collected packages: paho-mqtt
  Building wheel for paho-mqtt (setup.py) ... error
  ERROR: Command errored out with exit status 1:
   command: /home/mfr/Projects/virtual-can/.direnv/python-3.8.10/bin/python3 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-4oqdwr7u/paho-mqtt/setup.py'"'"'; __file__='"'"'/tmp/pip-install-4oqdwr7u/paho-mqtt/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-swwzebag
       cwd: /tmp/pip-install-4oqdwr7u/paho-mqtt/
  Complete output (6 lines):
  usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: setup.py --help [cmd1 cmd2 ...]
     or: setup.py --help-commands
     or: setup.py cmd --help
  
  error: invalid command 'bdist_wheel'
  ----------------------------------------
  ERROR: Failed building wheel for paho-mqtt
  Running setup.py clean for paho-mqtt
Failed to build paho-mqtt
```

